### PR TITLE
feat: add communication templates informations

### DIFF
--- a/src/main/java/fr/insee/pearljam/api/campaign/controller/CommunicationTemplateController.java
+++ b/src/main/java/fr/insee/pearljam/api/campaign/controller/CommunicationTemplateController.java
@@ -1,0 +1,39 @@
+package fr.insee.pearljam.api.campaign.controller;
+
+import fr.insee.pearljam.api.campaign.dto.output.CommunicationTemplateResponseDto;
+import fr.insee.pearljam.api.constants.Constants;
+import fr.insee.pearljam.domain.campaign.model.communication.CommunicationTemplate;
+import fr.insee.pearljam.domain.campaign.port.userside.CommunicationTemplateService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@Tag(name = "01. Campaigns", description = "Endpoints for campaigns")
+@Slf4j
+@RequiredArgsConstructor
+@Validated
+public class CommunicationTemplateController {
+    private final CommunicationTemplateService communicationTemplateService;
+
+    /**
+     * This method returns the list of visibilities associated with the
+     * campaign {id}
+     *
+     * @param campaignId campaign id
+     * @return List of {@link CommunicationTemplateResponseDto}
+     */
+    @Operation(summary = "Get campaign communication templates")
+    @GetMapping(path = Constants.API_CAMPAIGN_ID_COMMUNICATION_TEMPLATES)
+    public List<CommunicationTemplateResponseDto> getCommunicationTemplates(
+            @NotBlank @PathVariable(value = "id") String campaignId) {
+        List<CommunicationTemplate> communicationTemplates = communicationTemplateService.findCommunicationTemplates(campaignId);
+        return CommunicationTemplateResponseDto.fromModel(communicationTemplates);
+    }
+}

--- a/src/main/java/fr/insee/pearljam/api/campaign/dto/output/CommunicationTemplateResponseDto.java
+++ b/src/main/java/fr/insee/pearljam/api/campaign/dto/output/CommunicationTemplateResponseDto.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 public record CommunicationTemplateResponseDto(
         Long id,
-        String messhugahId,
         CommunicationMedium medium,
         CommunicationType type
 ) {
@@ -17,7 +16,6 @@ public record CommunicationTemplateResponseDto(
                 .map(communicationTemplate ->
                         new CommunicationTemplateResponseDto(
                                 communicationTemplate.id(),
-                                communicationTemplate.meshuggahId(),
                                 communicationTemplate.medium(),
                                 communicationTemplate.type()))
                 .toList();

--- a/src/main/java/fr/insee/pearljam/api/constants/Constants.java
+++ b/src/main/java/fr/insee/pearljam/api/constants/Constants.java
@@ -21,7 +21,7 @@ public class Constants {
 	public static final String API_SURVEYUNITS = "/api/survey-units";
 	public static final String API_SURVEYUNITS_INTERVIEWERS = "/api/survey-units/interviewers";
 	public static final String API_SURVEYUNITS_CLOSABLE = "/api/survey-units/closable";
-
+	public static final String API_SURVEYUNIT_ID_INTERVIEWER = "/api/interviewer/survey-unit/{id}";
 	public static final String API_SURVEYUNIT_ID = "/api/survey-unit/{id}";
 	public static final String API_SURVEYUNIT_ID_STATE = "/api/survey-unit/{id}/state/{state}";
 	public static final String API_SURVEYUNIT_ID_STATES = "/api/survey-unit/{id}/states";

--- a/src/main/java/fr/insee/pearljam/api/constants/Constants.java
+++ b/src/main/java/fr/insee/pearljam/api/constants/Constants.java
@@ -55,6 +55,7 @@ public class Constants {
 	public static final String API_CAMPAIGN_ID_SU_INTERVIEWER_CLOSINGCAUSES = "/api/campaign/{id}/survey-units/interviewer/{idep}/closing-causes";
 	public static final String API_CAMPAIGN_ID_OU_ID_VISIBILITY = "/api/campaign/{idCampaign}/organizational-unit/{idOu}/visibility";
 	public static final String API_CAMPAIGN_ID_VISIBILITIES = "/api/campaign/{id}/visibilities";
+	public static final String API_CAMPAIGN_ID_COMMUNICATION_TEMPLATES = "/api/campaign/{id}/communication-templates";
 	public static final String API_CAMPAIGN_ID_REFERENTS = "/api/campaigns/{id}/referents";
 	public static final String API_CAMPAIGNS_ID_ON_GOING = "/campaigns/{id}/ongoing";
 

--- a/src/main/java/fr/insee/pearljam/api/controller/SurveyUnitController.java
+++ b/src/main/java/fr/insee/pearljam/api/controller/SurveyUnitController.java
@@ -114,7 +114,7 @@ public class SurveyUnitController {
 	 *         {@link HttpStatus} FORBIDDEN
 	 */
 	@Operation(summary = "Get detail of specific survey unit ")
-	@GetMapping(path = "/interviewer/survey-unit/{id}")
+	@GetMapping(path = {"/interviewer/survey-unit/{id}", "/survey-unit/{id}"})
 	public SurveyUnitInterviewerResponseDto getSurveyUnitById(@PathVariable(value = "id") String surveyUnitId) {
 		String userId = authenticatedUserService.getCurrentUserId();
 		return surveyUnitService.getSurveyUnitInterviewerDetail(userId, surveyUnitId);

--- a/src/main/java/fr/insee/pearljam/api/repository/SurveyUnitRepository.java
+++ b/src/main/java/fr/insee/pearljam/api/repository/SurveyUnitRepository.java
@@ -46,11 +46,11 @@ public interface SurveyUnitRepository extends JpaRepository<SurveyUnit, String> 
 
 	/**
 	 * This method retrieve the SurveyUnit in DB by Id and UserId
-	 * @param id
-	 * @param userId
-	 * @return SurveyUnit
+	 * @param surveyUnitId survey unit id
+	 * @param userId user id
+	 * @return the survey unit
 	 */
-	Optional<SurveyUnit> findByIdAndInterviewerIdIgnoreCase(String id, String userId);
+	Optional<SurveyUnit> findByIdAndInterviewerIdIgnoreCase(String surveyUnitId, String userId);
 
 	/**
 	 * This method retrieve all the Ids of the SurveyUnits in db

--- a/src/main/java/fr/insee/pearljam/api/service/SurveyUnitService.java
+++ b/src/main/java/fr/insee/pearljam/api/service/SurveyUnitService.java
@@ -1,13 +1,14 @@
 package fr.insee.pearljam.api.service;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import fr.insee.pearljam.api.dto.surveyunit.*;
+import fr.insee.pearljam.api.surveyunit.dto.SurveyUnitInterviewerResponseDto;
 import fr.insee.pearljam.api.surveyunit.dto.SurveyUnitUpdateDto;
 import fr.insee.pearljam.domain.exception.PersonNotFoundException;
 import fr.insee.pearljam.domain.exception.SurveyUnitNotFoundException;
+import fr.insee.pearljam.domain.surveyunit.model.SurveyUnitForInterviewer;
 import jakarta.servlet.http.HttpServletRequest;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -15,8 +16,6 @@ import fr.insee.pearljam.api.domain.*;
 import org.springframework.http.HttpStatus;
 
 import fr.insee.pearljam.api.dto.state.StateDto;
-import fr.insee.pearljam.api.exception.NotFoundException;
-import fr.insee.pearljam.api.exception.SurveyUnitException;
 
 /**
  * Service for the SurveyUnit entity
@@ -28,14 +27,12 @@ public interface SurveyUnitService {
 
 	/**
 	 * Retrieve the SurveyUnitDetail entity by Id and UserId
-	 * 
-	 * @param userId
-	 * @param id
-	 * @return {@link SurveyUnitDetailDto}
-	 * @throws SurveyUnitException
-	 * @throws NotFoundException
+	 *
+	 * @param userId       user id
+	 * @param surveyUnitId survey unit id
+	 * @return {@link SurveyUnitForInterviewer}
 	 */
-	SurveyUnitDetailDto getSurveyUnitDetail(String userId, String id) throws SurveyUnitException, NotFoundException;
+	SurveyUnitInterviewerResponseDto getSurveyUnitInterviewerDetail(String userId, String surveyUnitId);
 
 	/**
 	 * Retrieve all the SurveyUnit entity by userId
@@ -78,9 +75,12 @@ public interface SurveyUnitService {
 	 */
 	List<StateDto> getListStatesBySurveyUnitId(String suId);
 
-	public Optional<SurveyUnit> findByIdAndInterviewerIdIgnoreCase(String userId, String id);
-
-	public Optional<SurveyUnit> findById(String id);
+	/**
+	 *
+	 * @param surveyUnitId survey unit id
+	 * @return {@link SurveyUnit} the survey unit
+	 */
+	SurveyUnit getSurveyUnit(String surveyUnitId);
 
 	List<SurveyUnitCampaignDto> getClosableSurveyUnits(HttpServletRequest request, String userId);
 
@@ -100,7 +100,7 @@ public interface SurveyUnitService {
 
 	boolean checkHabilitationReviewer(String userId, String id);
 
-	void delete(SurveyUnit surveyUnit);
+	void delete(String surveyUnitId);
 
 	void saveSurveyUnitToTempZone(String id, String userId, JsonNode surveyUnit);
 

--- a/src/main/java/fr/insee/pearljam/api/service/impl/CampaignServiceImpl.java
+++ b/src/main/java/fr/insee/pearljam/api/service/impl/CampaignServiceImpl.java
@@ -197,7 +197,8 @@ public class CampaignServiceImpl implements CampaignService {
 		if (!force && isCampaignOngoing(campaignId)) {
 			throw new CampaignOnGoingException();
 		}
-		surveyUnitRepository.findByCampaignId(campaign.getId()).stream().forEach(surveyUnitService::delete);
+		surveyUnitRepository.findByCampaignId(campaign.getId())
+				.forEach(surveyunit -> surveyUnitService.delete(surveyunit.getId()));
 		userRepository.findAll()
 				.forEach(user -> {
 					List<String> lstCampaignId = new ArrayList<>(user.getCampaigns().stream().map(Campaign::getId)

--- a/src/main/java/fr/insee/pearljam/api/surveyunit/dto/SurveyUnitInterviewerResponseDto.java
+++ b/src/main/java/fr/insee/pearljam/api/surveyunit/dto/SurveyUnitInterviewerResponseDto.java
@@ -1,0 +1,72 @@
+package fr.insee.pearljam.api.surveyunit.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import fr.insee.pearljam.api.bussinessrules.BussinessRules;
+import fr.insee.pearljam.api.campaign.dto.output.CommunicationTemplateResponseDto;
+import fr.insee.pearljam.api.domain.State;
+import fr.insee.pearljam.api.domain.SurveyUnit;
+import fr.insee.pearljam.api.dto.address.AddressDto;
+import fr.insee.pearljam.api.dto.contactattempt.ContactAttemptDto;
+import fr.insee.pearljam.api.dto.contactoutcome.ContactOutcomeDto;
+import fr.insee.pearljam.api.dto.person.PersonDto;
+import fr.insee.pearljam.api.dto.sampleidentifier.SampleIdentifiersDto;
+import fr.insee.pearljam.api.dto.state.StateDto;
+import fr.insee.pearljam.domain.surveyunit.model.SurveyUnitForInterviewer;
+
+import java.util.Comparator;
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SurveyUnitInterviewerResponseDto(
+	String id,
+	List<PersonDto> persons,
+	AddressDto address,
+	Boolean priority,
+	Boolean move,
+	String campaign,
+	List<CommentDto> comments,
+	SampleIdentifiersDto sampleIdentifiers,
+	List<StateDto> states,
+	List<ContactAttemptDto> contactAttempts,
+	ContactOutcomeDto contactOutcome,
+	IdentificationDto identification,
+	List<CommunicationTemplateResponseDto> communicationTemplates,
+	List<CommunicationRequestResponseDto> communicationRequests) {
+
+	public static SurveyUnitInterviewerResponseDto fromModel(SurveyUnitForInterviewer surveyUnitForInterviewer) {
+		SurveyUnit surveyUnit = surveyUnitForInterviewer.surveyUnit();
+		List<PersonDto> persons = surveyUnit.getPersons().stream()
+				.map(PersonDto::new)
+				.toList();
+
+		List<CommentDto> comments = CommentDto.fromModel(surveyUnit.getModelComments());
+		AddressDto address = new AddressDto(surveyUnit.getAddress());
+		List<ContactAttemptDto> contactAttempts = surveyUnit
+				.getContactAttempts()
+				.stream()
+				.map(ContactAttemptDto::new)
+				.toList();
+		List<StateDto> states = surveyUnit
+				.getStates()
+				.stream()
+				.sorted(Comparator.comparing(State::getDate, Comparator.nullsLast(Comparator.reverseOrder())))
+				.filter(s -> BussinessRules.stateCanBeSeenByInterviewerBussinessRules(s.getType()))
+				.map(StateDto::new)
+				.toList();
+		ContactOutcomeDto contactOutcome = null;
+		if (surveyUnit.getContactOucome() != null) {
+			contactOutcome = new ContactOutcomeDto(surveyUnit.getContactOucome());
+		}
+
+		SampleIdentifiersDto sampleIdentifiers = null;
+		if (surveyUnit.getSampleIdentifier() != null) {
+			sampleIdentifiers = new SampleIdentifiersDto(surveyUnit.getSampleIdentifier());
+		}
+		return new SurveyUnitInterviewerResponseDto(surveyUnit.getId(), persons, address,
+				surveyUnit.isPriority(), surveyUnit.getMove(), surveyUnit.getCampaign().getId(),
+				comments, sampleIdentifiers, states, contactAttempts, contactOutcome,
+				IdentificationDto.fromModel(surveyUnit.getModelIdentification()),
+				CommunicationTemplateResponseDto.fromModel(surveyUnitForInterviewer.communicationTemplates()),
+				CommunicationRequestResponseDto.fromModel(surveyUnit.getModelCommunicationRequests()));
+	}
+}

--- a/src/main/java/fr/insee/pearljam/api/web/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/fr/insee/pearljam/api/web/exception/ExceptionControllerAdvice.java
@@ -130,6 +130,11 @@ public class ExceptionControllerAdvice {
         return generateResponseError(e, HttpStatus.NOT_FOUND, request);
     }
 
+    @ExceptionHandler(SurveyUnitNotFoundException.class)
+    public ResponseEntity<ApiError> exceptions(SurveyUnitNotFoundException e, WebRequest request) {
+        return generateResponseError(e, HttpStatus.NOT_FOUND, request);
+    }
+
     @ExceptionHandler(VisibilityHasInvalidDatesException.class)
     public ResponseEntity<ApiError> exceptions(VisibilityHasInvalidDatesException e, WebRequest request) {
         return generateResponseError(e, HttpStatus.CONFLICT, request);

--- a/src/main/java/fr/insee/pearljam/domain/campaign/port/serverside/CommunicationTemplateRepository.java
+++ b/src/main/java/fr/insee/pearljam/domain/campaign/port/serverside/CommunicationTemplateRepository.java
@@ -1,0 +1,14 @@
+package fr.insee.pearljam.domain.campaign.port.serverside;
+
+import fr.insee.pearljam.domain.campaign.model.communication.CommunicationTemplate;
+
+import java.util.List;
+
+public interface CommunicationTemplateRepository {
+    /**
+     *
+     * @param campaignId campaign id
+     * @return list of communication templates for a campaign
+     */
+    List<CommunicationTemplate> findCommunicationTemplates(String campaignId);
+}

--- a/src/main/java/fr/insee/pearljam/domain/campaign/port/userside/CommunicationTemplateService.java
+++ b/src/main/java/fr/insee/pearljam/domain/campaign/port/userside/CommunicationTemplateService.java
@@ -1,0 +1,14 @@
+package fr.insee.pearljam.domain.campaign.port.userside;
+
+import fr.insee.pearljam.domain.campaign.model.communication.CommunicationTemplate;
+
+import java.util.List;
+
+public interface CommunicationTemplateService {
+
+    /**
+     * @param campaignId campaign id
+     * @return the communication templates for a campaign
+     */
+    List<CommunicationTemplate> findCommunicationTemplates(String campaignId);
+}

--- a/src/main/java/fr/insee/pearljam/domain/campaign/service/CommunicationTemplateServiceImpl.java
+++ b/src/main/java/fr/insee/pearljam/domain/campaign/service/CommunicationTemplateServiceImpl.java
@@ -1,0 +1,20 @@
+package fr.insee.pearljam.domain.campaign.service;
+
+import fr.insee.pearljam.domain.campaign.model.communication.CommunicationTemplate;
+import fr.insee.pearljam.domain.campaign.port.serverside.CommunicationTemplateRepository;
+import fr.insee.pearljam.domain.campaign.port.userside.CommunicationTemplateService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CommunicationTemplateServiceImpl implements CommunicationTemplateService {
+    private final CommunicationTemplateRepository communicationTemplateRepository;
+
+    @Override
+    public List<CommunicationTemplate> findCommunicationTemplates(String campaignId) {
+        return communicationTemplateRepository.findCommunicationTemplates(campaignId);
+    }
+}

--- a/src/main/java/fr/insee/pearljam/domain/exception/SurveyUnitNotFoundException.java
+++ b/src/main/java/fr/insee/pearljam/domain/exception/SurveyUnitNotFoundException.java
@@ -1,10 +1,10 @@
 package fr.insee.pearljam.domain.exception;
 
-public class SurveyUnitNotFoundException extends EntityNotFoundException {
+public class SurveyUnitNotFoundException extends RuntimeException {
 
-    public static final String MESSAGE = "Survey unit not found";
+    public static final String MESSAGE = "Survey unit %s not found";
 
-    public SurveyUnitNotFoundException() {
-        super(MESSAGE);
+    public SurveyUnitNotFoundException(String id) {
+        super(String.format(MESSAGE, id));
     }
 }

--- a/src/main/java/fr/insee/pearljam/domain/surveyunit/model/SurveyUnitForInterviewer.java
+++ b/src/main/java/fr/insee/pearljam/domain/surveyunit/model/SurveyUnitForInterviewer.java
@@ -1,0 +1,12 @@
+package fr.insee.pearljam.domain.surveyunit.model;
+
+import fr.insee.pearljam.api.domain.SurveyUnit;
+import fr.insee.pearljam.domain.campaign.model.communication.CommunicationTemplate;
+
+import java.util.List;
+
+public record SurveyUnitForInterviewer(
+        SurveyUnit surveyUnit,
+        List<CommunicationTemplate> communicationTemplates
+) {
+}

--- a/src/main/java/fr/insee/pearljam/infrastructure/campaign/adapter/CommunicationTemplateDaoAdapter.java
+++ b/src/main/java/fr/insee/pearljam/infrastructure/campaign/adapter/CommunicationTemplateDaoAdapter.java
@@ -1,0 +1,24 @@
+package fr.insee.pearljam.infrastructure.campaign.adapter;
+
+import fr.insee.pearljam.domain.campaign.model.communication.CommunicationTemplate;
+import fr.insee.pearljam.domain.campaign.port.serverside.CommunicationTemplateRepository;
+import fr.insee.pearljam.infrastructure.campaign.entity.CommunicationTemplateDB;
+import fr.insee.pearljam.infrastructure.campaign.jpa.CommunicationTemplateJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CommunicationTemplateDaoAdapter implements CommunicationTemplateRepository {
+
+    private final CommunicationTemplateJpaRepository communicationTemplateRepository;
+
+    @Override
+    public List<CommunicationTemplate> findCommunicationTemplates(String campaignId) {
+        List<CommunicationTemplateDB> communicationTemplates = communicationTemplateRepository
+                .findCommunicationTemplates(campaignId);
+        return CommunicationTemplateDB.toModel(communicationTemplates);
+    }
+}

--- a/src/main/java/fr/insee/pearljam/infrastructure/campaign/jpa/CommunicationTemplateJpaRepository.java
+++ b/src/main/java/fr/insee/pearljam/infrastructure/campaign/jpa/CommunicationTemplateJpaRepository.java
@@ -4,6 +4,7 @@ import fr.insee.pearljam.infrastructure.campaign.entity.CommunicationTemplateDB;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CommunicationTemplateJpaRepository extends JpaRepository<CommunicationTemplateDB, Long> {
@@ -13,4 +14,9 @@ public interface CommunicationTemplateJpaRepository extends JpaRepository<Commun
         WHERE c.id = ?1
         AND c.campaign.id = ?2""")
     Optional<CommunicationTemplateDB> findCommunicationTemplate(Long communicationTemplateId, String campaignId);
+
+    @Query("""
+        SELECT c FROM CommunicationTemplateDB c
+        WHERE c.campaign.id = ?1""")
+    List<CommunicationTemplateDB> findCommunicationTemplates(String campaignId);
 }

--- a/src/main/java/fr/insee/pearljam/infrastructure/security/config/OidcSecurityConfiguration.java
+++ b/src/main/java/fr/insee/pearljam/infrastructure/security/config/OidcSecurityConfiguration.java
@@ -110,7 +110,7 @@ public class OidcSecurityConfiguration {
 						.hasRole(adminRole)
 						.requestMatchers(HttpMethod.GET, Constants.API_SURVEYUNITS_CLOSABLE)
 						.hasAnyRole(adminRole, localUserRole, nationalUserRole)
-						.requestMatchers(HttpMethod.GET, Constants.API_SURVEYUNIT_ID_INTERVIEWER)
+						.requestMatchers(HttpMethod.GET, Constants.API_SURVEYUNIT_ID_INTERVIEWER, Constants.API_SURVEYUNIT_ID)
 						.hasAnyRole(adminRole, interviewerRole)
 						.requestMatchers(HttpMethod.PUT, Constants.API_SURVEYUNIT_ID)
 						.hasAnyRole(adminRole, interviewerRole)

--- a/src/main/java/fr/insee/pearljam/infrastructure/security/config/OidcSecurityConfiguration.java
+++ b/src/main/java/fr/insee/pearljam/infrastructure/security/config/OidcSecurityConfiguration.java
@@ -176,6 +176,8 @@ public class OidcSecurityConfiguration {
 						.hasAnyRole(adminRole, localUserRole, nationalUserRole)
 						.requestMatchers(HttpMethod.GET, Constants.API_CAMPAIGN_ID_VISIBILITIES)
 						.hasRole(adminRole)
+						.requestMatchers(HttpMethod.GET, Constants.API_CAMPAIGN_ID_COMMUNICATION_TEMPLATES)
+						.hasRole(adminRole)
 						.requestMatchers(HttpMethod.GET, Constants.API_CAMPAIGN_ID_REFERENTS)
 						.hasAnyRole(adminRole, localUserRole, nationalUserRole)
 						.requestMatchers(HttpMethod.GET, Constants.API_CAMPAIGNS_ID_ON_GOING)

--- a/src/main/java/fr/insee/pearljam/infrastructure/security/config/OidcSecurityConfiguration.java
+++ b/src/main/java/fr/insee/pearljam/infrastructure/security/config/OidcSecurityConfiguration.java
@@ -110,7 +110,7 @@ public class OidcSecurityConfiguration {
 						.hasRole(adminRole)
 						.requestMatchers(HttpMethod.GET, Constants.API_SURVEYUNITS_CLOSABLE)
 						.hasAnyRole(adminRole, localUserRole, nationalUserRole)
-						.requestMatchers(HttpMethod.GET, Constants.API_SURVEYUNIT_ID)
+						.requestMatchers(HttpMethod.GET, Constants.API_SURVEYUNIT_ID_INTERVIEWER)
 						.hasAnyRole(adminRole, interviewerRole)
 						.requestMatchers(HttpMethod.PUT, Constants.API_SURVEYUNIT_ID)
 						.hasAnyRole(adminRole, interviewerRole)

--- a/src/main/java/fr/insee/pearljam/infrastructure/surveyunit/adapter/CommentDaoAdapter.java
+++ b/src/main/java/fr/insee/pearljam/infrastructure/surveyunit/adapter/CommentDaoAdapter.java
@@ -23,7 +23,7 @@ public class CommentDaoAdapter implements CommentRepository {
     public void updateComment(Comment comment) throws SurveyUnitNotFoundException {
         SurveyUnit surveyUnit = surveyUnitRepository
                 .findById(comment.surveyUnitId())
-                .orElseThrow(SurveyUnitNotFoundException::new);
+                .orElseThrow(() -> new SurveyUnitNotFoundException(comment.surveyUnitId()));
 
         Set<CommentDB> existingComments = surveyUnit.getComments();
 

--- a/src/test/java/fr/insee/pearljam/api/authKeycloak/TestAuthKeyCloak.java
+++ b/src/test/java/fr/insee/pearljam/api/authKeycloak/TestAuthKeyCloak.java
@@ -513,8 +513,8 @@ class TestAuthKeyCloak {
 	 */
 	@Test
 	@Order(13)
-	void testGetSurveyUnitDetailNotFound() throws Exception {
-		mockMvc.perform(get("/api/survey-unit/123456789")
+	void testGetSurveyUnitInterviewerDetailNotFound() throws Exception {
+		mockMvc.perform(get("/api/interviewer/survey-unit/123456789")
 				.with(authentication(ADMIN))
 				.accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isNotFound());
@@ -1148,7 +1148,7 @@ class TestAuthKeyCloak {
 				.content(comment))
 				.andExpect(status().isOk());
 
-		mockMvc.perform(get("/api/survey-unit/11")
+		mockMvc.perform(get("/api/interviewer/survey-unit/11")
 				.with(authentication(INTERVIEWER))
 				.accept(MediaType.APPLICATION_JSON))
 				.andExpectAll(

--- a/src/test/java/fr/insee/pearljam/api/campaign/dto/output/CommunicationTemplateResponseDtoTest.java
+++ b/src/test/java/fr/insee/pearljam/api/campaign/dto/output/CommunicationTemplateResponseDtoTest.java
@@ -28,13 +28,11 @@ class CommunicationTemplateResponseDtoTest {
 
         CommunicationTemplateResponseDto dto1 = communicationDtos.get(0);
         assertThat(dto1.id()).isEqualTo(1L);
-        assertThat(dto1.messhugahId()).isEqualTo("msg1");
         assertThat(dto1.medium()).isEqualTo(CommunicationMedium.EMAIL);
         assertThat(dto1.type()).isEqualTo(CommunicationType.NOTICE);
 
         CommunicationTemplateResponseDto dto2 = communicationDtos.get(1);
         assertThat(dto2.id()).isEqualTo(2L);
-        assertThat(dto2.messhugahId()).isEqualTo("msg2");
         assertThat(dto2.medium()).isEqualTo(CommunicationMedium.LETTER);
         assertThat(dto2.type()).isEqualTo(CommunicationType.REMINDER);
     }

--- a/src/test/java/fr/insee/pearljam/api/surveyunit/controller/CommentControllerTest.java
+++ b/src/test/java/fr/insee/pearljam/api/surveyunit/controller/CommentControllerTest.java
@@ -108,7 +108,7 @@ class CommentControllerTest {
                 .andExpectAll(status().isNotFound(),
                         jsonPath("$.code").value(HttpStatus.NOT_FOUND.value()),
                         jsonPath("$.path").value(updatePath),
-                        jsonPath("$.message").value(SurveyUnitNotFoundException.MESSAGE),
+                        jsonPath("$.message").value(String.format(SurveyUnitNotFoundException.MESSAGE, "1")),
                         jsonPath("$.timestamp", new StructureDateMatcher()));
         assertThat(commentService.getCommentUpdated()).isNull();
     }

--- a/src/test/java/fr/insee/pearljam/api/surveyunit/controller/SurveyUnitControllerTest.java
+++ b/src/test/java/fr/insee/pearljam/api/surveyunit/controller/SurveyUnitControllerTest.java
@@ -111,7 +111,7 @@ class SurveyUnitControllerTest {
         mockMvc.perform(put(updatePath)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(surveyUnitJson))
-                .andExpect(MockMvcTestUtils.apiErrorMatches(HttpStatus.NOT_FOUND, updatePath, SurveyUnitNotFoundException.MESSAGE));
+                .andExpect(MockMvcTestUtils.apiErrorMatches(HttpStatus.NOT_FOUND, updatePath, String.format(SurveyUnitNotFoundException.MESSAGE,1)));
         assertThat(surveyUnitService.getSurveyUnitUpdated()).isNull();
     }
 

--- a/src/test/java/fr/insee/pearljam/api/surveyunit/controller/dummy/CommentFakeService.java
+++ b/src/test/java/fr/insee/pearljam/api/surveyunit/controller/dummy/CommentFakeService.java
@@ -16,7 +16,7 @@ public class CommentFakeService implements CommentService {
     @Override
     public void updateSurveyUnitComment(Comment comment) throws SurveyUnitNotFoundException {
         if(shouldThrowException) {
-            throw new SurveyUnitNotFoundException();
+            throw new SurveyUnitNotFoundException(comment.surveyUnitId());
         }
         commentUpdated = comment;
     }

--- a/src/test/java/fr/insee/pearljam/api/surveyunit/controller/dummy/SurveyUnitFakeService.java
+++ b/src/test/java/fr/insee/pearljam/api/surveyunit/controller/dummy/SurveyUnitFakeService.java
@@ -4,9 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import fr.insee.pearljam.api.domain.*;
 import fr.insee.pearljam.api.dto.state.StateDto;
 import fr.insee.pearljam.api.dto.surveyunit.*;
-import fr.insee.pearljam.api.exception.NotFoundException;
-import fr.insee.pearljam.api.exception.SurveyUnitException;
 import fr.insee.pearljam.api.service.SurveyUnitService;
+import fr.insee.pearljam.api.surveyunit.dto.SurveyUnitInterviewerResponseDto;
 import fr.insee.pearljam.api.surveyunit.dto.SurveyUnitUpdateDto;
 import fr.insee.pearljam.domain.exception.PersonNotFoundException;
 import fr.insee.pearljam.domain.exception.SurveyUnitNotFoundException;
@@ -16,7 +15,6 @@ import lombok.Setter;
 import org.springframework.http.HttpStatus;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 public class SurveyUnitFakeService implements SurveyUnitService {
@@ -31,19 +29,14 @@ public class SurveyUnitFakeService implements SurveyUnitService {
     private SurveyUnitUpdateDto surveyUnitUpdated = null;
 
     @Override
-    public SurveyUnitDetailDto getSurveyUnitDetail(String userId, String id) throws SurveyUnitException, NotFoundException {
-        throw new IllegalArgumentException("not implemented yet");
-    }
-
-    @Override
     public List<SurveyUnitDto> getSurveyUnitDto(String userId, Boolean extended) {
         throw new IllegalArgumentException("not implemented yet");
     }
 
     @Override
-    public SurveyUnitDetailDto updateSurveyUnit(String userId, String id, SurveyUnitUpdateDto surveyUnitUpdateDto) throws SurveyUnitNotFoundException, PersonNotFoundException {
+    public SurveyUnitDetailDto updateSurveyUnit(String userId, String surveyUnitId, SurveyUnitUpdateDto surveyUnitUpdateDto) throws SurveyUnitNotFoundException, PersonNotFoundException {
         if(shouldThrowSurveyUnitException) {
-            throw new SurveyUnitNotFoundException();
+            throw new SurveyUnitNotFoundException(surveyUnitId);
         }
 
         if(shouldThrowPersonException) {
@@ -69,12 +62,7 @@ public class SurveyUnitFakeService implements SurveyUnitService {
     }
 
     @Override
-    public Optional<SurveyUnit> findByIdAndInterviewerIdIgnoreCase(String userId, String id) {
-        throw new IllegalArgumentException("not implemented yet");
-    }
-
-    @Override
-    public Optional<SurveyUnit> findById(String id) {
+    public SurveyUnit getSurveyUnit(String surveyUnitId) {
         throw new IllegalArgumentException("not implemented yet");
     }
 
@@ -124,7 +112,7 @@ public class SurveyUnitFakeService implements SurveyUnitService {
     }
 
     @Override
-    public void delete(SurveyUnit surveyUnit) {
+    public void delete(String surveyUnitId) {
         throw new IllegalArgumentException("not implemented yet");
     }
 
@@ -161,5 +149,10 @@ public class SurveyUnitFakeService implements SurveyUnitService {
     @Override
     public void removeInterviewerLink(List<String> ids) {
         throw new IllegalArgumentException("not implemented yet");
+    }
+
+    @Override
+    public SurveyUnitInterviewerResponseDto getSurveyUnitInterviewerDetail(String userId, String surveyUnitId) {
+        return null;
     }
 }

--- a/src/test/java/fr/insee/pearljam/domain/campaign/service/dummy/SurveyUnitFakeRepository.java
+++ b/src/test/java/fr/insee/pearljam/domain/campaign/service/dummy/SurveyUnitFakeRepository.java
@@ -27,7 +27,7 @@ public class SurveyUnitFakeRepository implements SurveyUnitRepository {
     }
 
     @Override
-    public Optional<SurveyUnit> findByIdAndInterviewerIdIgnoreCase(String id, String userId) {
+    public Optional<SurveyUnit> findByIdAndInterviewerIdIgnoreCase(String surveyUnitId, String userId) {
         return Optional.empty();
     }
 

--- a/src/test/java/fr/insee/pearljam/domain/surveyunit/service/dummy/CommentFakeRepository.java
+++ b/src/test/java/fr/insee/pearljam/domain/surveyunit/service/dummy/CommentFakeRepository.java
@@ -19,7 +19,7 @@ public class CommentFakeRepository implements CommentRepository {
     @Override
     public void updateComment(Comment comment) throws SurveyUnitNotFoundException {
         if(shouldThrowException) {
-            throw new SurveyUnitNotFoundException();
+            throw new SurveyUnitNotFoundException(comment.surveyUnitId());
         }
         commentUpdated = comment;
     }

--- a/src/test/java/fr/insee/pearljam/infrastructure/surveyunit/adapter/CommentDaoAdapterTest.java
+++ b/src/test/java/fr/insee/pearljam/infrastructure/surveyunit/adapter/CommentDaoAdapterTest.java
@@ -79,10 +79,11 @@ class CommentDaoAdapterTest {
     @Test
     @DisplayName("Should throw exception when survey unit doesn't exist")
     void testUpdateComment02() {
-        Comment comment = new Comment(CommentType.INTERVIEWER, "value4", "marvelous-id");
+        String invalidSurveyUnitId = "invalid-id";
+        Comment comment = new Comment(CommentType.INTERVIEWER, "value4", invalidSurveyUnitId);
         assertThatThrownBy(() -> commentDaoAdapter.updateComment(comment))
                 .isInstanceOf(SurveyUnitNotFoundException.class)
-                .hasMessage(SurveyUnitNotFoundException.MESSAGE);
+                .hasMessage(String.format(SurveyUnitNotFoundException.MESSAGE, invalidSurveyUnitId));
     }
 }
 

--- a/src/test/java/fr/insee/pearljam/integration/campaign/CommunicationTemplateIT.java
+++ b/src/test/java/fr/insee/pearljam/integration/campaign/CommunicationTemplateIT.java
@@ -1,0 +1,53 @@
+package fr.insee.pearljam.integration.campaign;
+
+import fr.insee.pearljam.api.utils.AuthenticatedUserTestHelper;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@ActiveProfiles("auth")
+@AutoConfigureMockMvc
+@ContextConfiguration
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
+class CommunicationTemplateIT {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void testGetCommunicationTemplates() throws Exception {
+        MvcResult mvcResult = mockMvc.perform(get("/api/campaign/SIMPSONS2020X00/communication-templates")
+                        .with(authentication(AuthenticatedUserTestHelper.AUTH_ADMIN))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andReturn();
+
+        String contentResult = mvcResult.getResponse().getContentAsString();
+        String expectedResult = """
+            [
+               {
+                  "id":1,
+                  "medium":"EMAIL",
+                  "type":"REMINDER"
+               },
+               {
+                  "id":2,
+                  "medium":"LETTER",
+                  "type":"NOTICE"
+               }
+            ]
+        """;
+        JSONAssert.assertEquals(expectedResult, contentResult, JSONCompareMode.NON_EXTENSIBLE);
+    }
+}

--- a/src/test/java/fr/insee/pearljam/integration/surveyunit/SurveyUnitIT.java
+++ b/src/test/java/fr/insee/pearljam/integration/surveyunit/SurveyUnitIT.java
@@ -103,7 +103,7 @@ class SurveyUnitIT {
      */
     @Test
     void testGetSurveyUnitDetail() throws Exception {
-        MvcResult result = mockMvc.perform(get("/api/survey-unit/11")
+        MvcResult result = mockMvc.perform(get("/api/interviewer/survey-unit/11")
                         .with(authentication(AuthenticatedUserTestHelper.AUTH_INTERVIEWER))
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpectAll(status().isOk())
@@ -114,6 +114,28 @@ class SurveyUnitIT {
         {
            "id":"11",
            "persons":[
+              {
+                 "id":1,
+                 "title":"MISTER",
+                 "firstName":"Ted",
+                 "lastName":"Farmer",
+                 "email":"test@test.com",
+                 "birthdate":11111111,
+                 "favoriteEmail":true,
+                 "privileged":true,
+                 "phoneNumbers":[
+                    {
+                       "source":"FISCAL",
+                       "favorite":false,
+                       "number":"+33677542802"
+                    },
+                    {
+                       "source":"FISCAL",
+                       "favorite":true,
+                       "number":"+33677542802"
+                    }
+                 ]
+              },
               {
                  "id":6,
                  "title":"MISS",
@@ -141,28 +163,6 @@ class SurveyUnitIT {
                  "favoriteEmail":true,
                  "privileged":false,
                  "phoneNumbers":[
-                    {
-                       "source":"FISCAL",
-                       "favorite":true,
-                       "number":"+33677542802"
-                    }
-                 ]
-              },
-              {
-                 "id":1,
-                 "title":"MISTER",
-                 "firstName":"Ted",
-                 "lastName":"Farmer",
-                 "email":"test@test.com",
-                 "birthdate":11111111,
-                 "favoriteEmail":true,
-                 "privileged":true,
-                 "phoneNumbers":[
-                    {
-                       "source":"FISCAL",
-                       "favorite":false,
-                       "number":"+33677542802"
-                    },
                     {
                        "source":"FISCAL",
                        "favorite":true,
@@ -222,22 +222,19 @@ class SurveyUnitIT {
               "category":"PRIMARY",
               "occupant":"IDENTIFIED"
            },
-           "communicationRequests":[
+           "communicationTemplates":[
               {
-                 "communicationTemplateId":2,
-                 "reason":"UNREACHABLE",
-                 "emitter":"INTERVIEWER",
-                 "status":[
-                    {
-                       "date":1721903754305,
-                       "status":"INITIATED"
-                    },
-                    {
-                       "date":1721903756310,
-                       "status":"READY"
-                    }
-                 ]
+                 "id":1,
+                 "medium":"EMAIL",
+                 "type":"REMINDER"
               },
+              {
+                 "id":2,
+                 "medium":"LETTER",
+                 "type":"NOTICE"
+              }
+           ],
+           "communicationRequests":[
               {
                  "communicationTemplateId":1,
                  "reason":"REFUSAL",
@@ -254,6 +251,21 @@ class SurveyUnitIT {
                     {
                        "date":1721903756305,
                        "status":"SUBMITTED"
+                    }
+                 ]
+              },
+              {
+                 "communicationTemplateId":2,
+                 "reason":"UNREACHABLE",
+                 "emitter":"INTERVIEWER",
+                 "status":[
+                    {
+                       "date":1721903754305,
+                       "status":"INITIATED"
+                    },
+                    {
+                       "date":1721903756310,
+                       "status":"READY"
                     }
                  ]
               }


### PR DESCRIPTION
- endpoint exposing communication templates for a campaign
- return directly survey unit from service or throw exceptions
- refactor survey unit exception to return the survey unit id
- adapt the survey unit deletion with the above changes