### PR TITLE
Refine campaign interviewer query and tests

### DIFF
--- a/src/main/java/fr/insee/pearljam/api/controller/CampaignController.java
+++ b/src/main/java/fr/insee/pearljam/api/controller/CampaignController.java
@@ -33,11 +33,12 @@ import fr.insee.pearljam.api.campaign.dto.input.CampaignCreateDto;
 import fr.insee.pearljam.api.dto.campaign.CampaignDto;
 import fr.insee.pearljam.api.dto.campaign.OngoingDto;
 import fr.insee.pearljam.api.dto.count.CountDto;
-import fr.insee.pearljam.api.dto.interviewer.InterviewerDto;
+import fr.insee.pearljam.api.dto.interviewer.CampaignInterviewerDto;
 import fr.insee.pearljam.api.dto.referent.ReferentDto;
 import fr.insee.pearljam.api.exception.NotFoundException;
 import fr.insee.pearljam.api.service.CampaignService;
 import fr.insee.pearljam.api.service.ReferentService;
+import fr.insee.pearljam.api.service.InterviewerService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -51,9 +52,10 @@ import fr.insee.pearljam.api.constants.Constants;
 @Validated
 public class CampaignController {
 
-	private final CampaignService campaignService;
-	private final ReferentService referentService;
-	private final AuthenticatedUserService authenticatedUserService;
+        private final CampaignService campaignService;
+        private final ReferentService referentService;
+        private final InterviewerService interviewerService;
+        private final AuthenticatedUserService authenticatedUserService;
 
 	private static final String DEFAULT_FORCE_VALUE = "false";
 
@@ -132,17 +134,17 @@ public class CampaignController {
 	 */
 	@Operation(summary = "Get interviewers")
 	@GetMapping(path = Constants.API_CAMPAIGN_ID_INTERVIEWERS)
-	public ResponseEntity<List<InterviewerDto>> getListInterviewers(@PathVariable(value = "id") String id) {
-		String userId = authenticatedUserService.getCurrentUserId();
-		log.info("{} try to get campaign[{}] interviewers ", userId, id);
-		List<InterviewerDto> lstInterviewer;
-		try {
-			lstInterviewer = campaignService.getListInterviewers(userId, id);
-		} catch (NotFoundException e) {
-			log.error(e.getMessage());
-			log.info("Get interviewers resulting in 404");
-			return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-		}
+        public ResponseEntity<List<CampaignInterviewerDto>> getListInterviewers(@PathVariable(value = "id") String id) {
+                String userId = authenticatedUserService.getCurrentUserId();
+                log.info("{} try to get campaign[{}] interviewers ", userId, id);
+                List<CampaignInterviewerDto> lstInterviewer;
+                try {
+                        lstInterviewer = interviewerService.getListInterviewers(userId, id);
+                } catch (NotFoundException e) {
+                        log.error(e.getMessage());
+                        log.info("Get interviewers resulting in 404");
+                        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+                }
 
 		log.info("Get interviewers resulting in 200");
 		return new ResponseEntity<>(lstInterviewer, HttpStatus.OK);

--- a/src/main/java/fr/insee/pearljam/api/dto/interviewer/CampaignInterviewerDto.java
+++ b/src/main/java/fr/insee/pearljam/api/dto/interviewer/CampaignInterviewerDto.java
@@ -1,0 +1,22 @@
+package fr.insee.pearljam.api.dto.interviewer;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CampaignInterviewerDto {
+		private String id;
+		private String interviewerFirstName;
+		private String interviewerLastName;
+		private String email;
+		private String phoneNumber;
+		private Long surveyUnitCount;
+}

--- a/src/main/java/fr/insee/pearljam/api/repository/CampaignRepository.java
+++ b/src/main/java/fr/insee/pearljam/api/repository/CampaignRepository.java
@@ -10,7 +10,6 @@ import org.springframework.data.repository.query.Param;
 
 import fr.insee.pearljam.api.domain.Campaign;
 import fr.insee.pearljam.api.dto.campaign.CampaignDto;
-import fr.insee.pearljam.api.dto.interviewer.InterviewerDto;
 import fr.insee.pearljam.api.dto.message.VerifyNameResponseDto;
 
 /**
@@ -56,17 +55,8 @@ public interface CampaignRepository extends JpaRepository<Campaign, String> {
 			+ "AND pref.id_campaign = ?2", nativeQuery = true)
 	List<Integer> checkCampaignPreferences(String userId, String campaignId);
 
-	@Query("SELECT "
-			+ "new fr.insee.pearljam.api.dto.interviewer.InterviewerDto(interv.id, interv.firstName, interv.lastName, COUNT(su.interviewer)) "
-			+ "FROM SurveyUnit su "
-			+ "INNER JOIN Interviewer interv ON su.interviewer.id = interv.id "
-			+ "WHERE su.campaign.id=?1 "
-			+ "AND (su.organizationUnit.id=?2 OR ?2='GUEST') "
-			+ "GROUP BY interv.id")
-	List<InterviewerDto> findInterviewersDtoByCampaignIdAndOrganisationUnitId(String id, String organizationUnitId);
-
-	@Query(value = "SELECT v.organization_unit_id FROM visibility v WHERE v.campaign_id=?1", nativeQuery = true)
-	List<String> findAllOrganistionUnitIdByCampaignId(String campaignId);
+        @Query(value = "SELECT v.organization_unit_id FROM visibility v WHERE v.campaign_id=?1", nativeQuery = true)
+        List<String> findAllOrganistionUnitIdByCampaignId(String campaignId);
 
 	@Query("SELECT new fr.insee.pearljam.api.dto.message.VerifyNameResponseDto(camp.id,  'campaign', camp.label) "
 			+ "FROM Campaign camp "

--- a/src/main/java/fr/insee/pearljam/api/repository/InterviewerRepository.java
+++ b/src/main/java/fr/insee/pearljam/api/repository/InterviewerRepository.java
@@ -33,18 +33,18 @@ public interface InterviewerRepository extends JpaRepository<Interviewer, String
 			WHERE interv.id=?1""")
 	InterviewerContextDto findDtoById(String id);
 
-	@Query("SELECT interv "
-			+ "FROM Interviewer interv "
-			+ "INNER JOIN SurveyUnit su ON su.interviewer.id = interv.id "
-			+ "WHERE (su.organizationUnit.id in (:ouIds) OR 'GUEST' in (:ouIds)) "
-			+ "AND su.campaign.id=:campId "
-			+ "GROUP BY interv.id ")
-	List<Interviewer> findInterviewersWorkingOnCampaign(@Param("campId") String campId,
-			@Param("ouIds") List<String> ouIds);
+        @Query("SELECT interv "
+                        + "FROM Interviewer interv "
+                        + "INNER JOIN SurveyUnit su ON su.interviewer.id = interv.id "
+                        + "WHERE (su.organizationUnit.id in (:ouIds) OR 'GUEST' in (:ouIds)) "
+                        + "AND su.campaign.id=:campId "
+                        + "GROUP BY interv.id ")
+        List<Interviewer> findInterviewersWorkingOnCampaign(@Param("campId") String campId,
+                        @Param("ouIds") List<String> ouIds);
 
-	@Query("SELECT interv.id "
-			+ "FROM Interviewer interv "
-			+ "INNER JOIN SurveyUnit su "
+        @Query("SELECT interv.id "
+                        + "FROM Interviewer interv "
+                        + "INNER JOIN SurveyUnit su "
 			+ "ON su.interviewer.id = interv.id "
 			+ "WHERE (su.organizationUnit.id in (:ouIds) OR 'GUEST' in (:ouIds)) ")
 	List<String> findInterviewersByOrganizationUnits(@Param("ouIds") List<String> ouIds);

--- a/src/main/java/fr/insee/pearljam/api/service/CampaignService.java
+++ b/src/main/java/fr/insee/pearljam/api/service/CampaignService.java
@@ -46,9 +46,7 @@ public interface CampaignService {
 	 * @return {@link List} of {@link InterviewerDto}
 	 * @throws NotFoundException
 	 */
-	List<InterviewerDto> getListInterviewers(String userId, String campaignId) throws NotFoundException;
-
-	boolean isUserPreference(String userId, String campaignId);
+    boolean isUserPreference(String userId, String campaignId);
 
 	CountDto getNbSUAbandonedByCampaign(String userId, String campaignId) throws NotFoundException;
 

--- a/src/main/java/fr/insee/pearljam/api/service/InterviewerService.java
+++ b/src/main/java/fr/insee/pearljam/api/service/InterviewerService.java
@@ -6,8 +6,10 @@ import java.util.Set;
 
 import fr.insee.pearljam.api.domain.Response;
 import fr.insee.pearljam.api.dto.campaign.CampaignDto;
+import fr.insee.pearljam.api.dto.interviewer.CampaignInterviewerDto;
 import fr.insee.pearljam.api.dto.interviewer.InterviewerContextDto;
 import fr.insee.pearljam.api.dto.interviewer.InterviewerDto;
+import fr.insee.pearljam.api.exception.NotFoundException;
 
 /**
  * Service for the Campaign entity
@@ -19,9 +21,11 @@ public interface InterviewerService {
 
 	Optional<List<CampaignDto>> findCampaignsOfInterviewer(String interviewerId);
 
-	Response createInterviewers(List<InterviewerContextDto> interviewers);
+        Response createInterviewers(List<InterviewerContextDto> interviewers);
 
-	Set<InterviewerDto> getListInterviewers(String userId);
+        Set<InterviewerDto> getListInterviewers(String userId);
+
+        List<CampaignInterviewerDto> getListInterviewers(String userId, String campaignId) throws NotFoundException;
 
 	boolean delete(String id);
 

--- a/src/main/java/fr/insee/pearljam/api/service/impl/CampaignServiceImpl.java
+++ b/src/main/java/fr/insee/pearljam/api/service/impl/CampaignServiceImpl.java
@@ -12,7 +12,6 @@ import fr.insee.pearljam.api.dto.campaign.CampaignCommonsDto;
 import fr.insee.pearljam.api.dto.campaign.CampaignDto;
 import fr.insee.pearljam.api.dto.campaign.CampaignSensitivityDto;
 import fr.insee.pearljam.api.dto.count.CountDto;
-import fr.insee.pearljam.api.dto.interviewer.InterviewerDto;
 import fr.insee.pearljam.api.dto.organizationunit.OrganizationUnitDto;
 import fr.insee.pearljam.api.dto.referent.ReferentDto;
 import fr.insee.pearljam.api.exception.NotFoundException;
@@ -99,33 +98,10 @@ public class CampaignServiceImpl implements CampaignService {
 		return campaignDtoReturned;
 	}
 
-	@Override
-	public List<InterviewerDto> getListInterviewers(String userId, String campaignId) throws NotFoundException {
-		List<InterviewerDto> interviewersDtoReturned = new ArrayList<>();
-		if (!utilsService.checkUserCampaignOUConstraints(userId, campaignId)) {
-			throw new NotFoundException(String.format(USER_CAMP_CONST_MSG, campaignId, userId));
-		}
-
-		List<OrganizationUnitDto> organizationUnits = userService.getUserOUs(userId, false);
-		List<String> userOrgUnitIds = organizationUnits.stream().map(OrganizationUnitDto::getId)
-				.toList();
-
-		for (String orgId : campaignRepository.findAllOrganistionUnitIdByCampaignId(campaignId)) {
-			if (userOrgUnitIds.contains(orgId)) {
-				interviewersDtoReturned.addAll(
-						campaignRepository.findInterviewersDtoByCampaignIdAndOrganisationUnitId(campaignId, orgId));
-			}
-		}
-		if (interviewersDtoReturned.isEmpty()) {
-			log.warn("No interviewers found for the campaign {}", campaignId);
-		}
-		return interviewersDtoReturned;
-	}
-
-	@Override
-	public boolean isUserPreference(String userId, String campaignId) {
-		return (campaignRepository.checkCampaignPreferences(userId, campaignId).isEmpty()) || "GUEST".equals(userId);
-	}
+        @Override
+        public boolean isUserPreference(String userId, String campaignId) {
+                return (campaignRepository.checkCampaignPreferences(userId, campaignId).isEmpty()) || "GUEST".equals(userId);
+        }
 
 	@Override
 	public CountDto getNbSUAbandonedByCampaign(String userId, String campaignId) throws NotFoundException {

--- a/src/main/java/fr/insee/pearljam/domain/interviewer/model/CampaignInterviewer.java
+++ b/src/main/java/fr/insee/pearljam/domain/interviewer/model/CampaignInterviewer.java
@@ -1,0 +1,14 @@
+package fr.insee.pearljam.domain.interviewer.model;
+
+/**
+ * Lightweight projection representing an interviewer attached to a campaign
+ * with contact details and assigned survey-unit count.
+ */
+public record CampaignInterviewer(
+		String id,
+		String firstName,
+		String lastName,
+		String email,
+		String phoneNumber,
+		Long surveyUnitCount) {
+}

--- a/src/main/java/fr/insee/pearljam/domain/interviewer/port/serverside/CampaignInterviewerRepository.java
+++ b/src/main/java/fr/insee/pearljam/domain/interviewer/port/serverside/CampaignInterviewerRepository.java
@@ -1,0 +1,9 @@
+package fr.insee.pearljam.domain.interviewer.port.serverside;
+
+import fr.insee.pearljam.domain.interviewer.model.CampaignInterviewer;
+
+import java.util.List;
+
+public interface CampaignInterviewerRepository {
+	List<CampaignInterviewer> findCampaignInterviewers(String campaignId, List<String> organizationUnitIds);
+}

--- a/src/main/java/fr/insee/pearljam/infrastructure/interviewer/adapter/CampaignInterviewerDaoAdapter.java
+++ b/src/main/java/fr/insee/pearljam/infrastructure/interviewer/adapter/CampaignInterviewerDaoAdapter.java
@@ -1,0 +1,21 @@
+package fr.insee.pearljam.infrastructure.interviewer.adapter;
+
+import fr.insee.pearljam.domain.interviewer.model.CampaignInterviewer;
+import fr.insee.pearljam.domain.interviewer.port.serverside.CampaignInterviewerRepository;
+import fr.insee.pearljam.infrastructure.interviewer.jpa.CampaignInterviewerJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CampaignInterviewerDaoAdapter implements CampaignInterviewerRepository {
+
+	private final CampaignInterviewerJpaRepository campaignInterviewerJpaRepository;
+
+	@Override
+	public List<CampaignInterviewer> findCampaignInterviewers(String campaignId, List<String> organizationUnitIds) {
+		return campaignInterviewerJpaRepository.findCampaignInterviewers(campaignId, organizationUnitIds);
+	}
+}

--- a/src/main/java/fr/insee/pearljam/infrastructure/interviewer/jpa/CampaignInterviewerJpaRepository.java
+++ b/src/main/java/fr/insee/pearljam/infrastructure/interviewer/jpa/CampaignInterviewerJpaRepository.java
@@ -1,0 +1,30 @@
+package fr.insee.pearljam.infrastructure.interviewer.jpa;
+
+import fr.insee.pearljam.domain.interviewer.model.CampaignInterviewer;
+import fr.insee.pearljam.api.domain.Interviewer;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface CampaignInterviewerJpaRepository extends CrudRepository<Interviewer, String> {
+
+        @Query("""
+                        SELECT new fr.insee.pearljam.domain.interviewer.model.CampaignInterviewer(
+                                        interv.id,
+                                        interv.firstName,
+                                        interv.lastName,
+                                        interv.email,
+                                        interv.phoneNumber,
+                                        COUNT(su.interviewer))
+                        FROM SurveyUnit su
+                        INNER JOIN su.interviewer interv
+                        WHERE su.campaign.id=:campaignId
+                        AND (su.organizationUnit.id IN :organizationUnitIds OR 'GUEST' IN :organizationUnitIds)
+                        GROUP BY interv.id, interv.firstName, interv.lastName, interv.email, interv.phoneNumber
+                        """)
+	List<CampaignInterviewer> findCampaignInterviewers(
+			@Param("campaignId") String campaignId,
+			@Param("organizationUnitIds") List<String> organizationUnitIds);
+}

--- a/src/test/java/fr/insee/pearljam/api/authKeycloak/TestAuthKeyCloak.java
+++ b/src/test/java/fr/insee/pearljam/api/authKeycloak/TestAuthKeyCloak.java
@@ -304,15 +304,17 @@ class TestAuthKeyCloak {
 	@Order(4)
 	void testGetCampaignInterviewer() throws Exception {
 		String interviewerJsonPath = "$.[?(@.id == 'INTW1')].%s";
-		mockMvc.perform(get("/api/campaign/SIMPSONS2020X00/interviewers")
-						.with(authentication(LOCAL_USER))
-						.accept(MediaType.APPLICATION_JSON))
-				.andExpectAll(
-						status().isOk(),
-						checkJsonPath(interviewerJsonPath, "interviewerFirstName", "Margie"),
-						checkJsonPath(interviewerJsonPath, "interviewerLastName", "Lucas"),
-						checkJsonPath(interviewerJsonPath, "surveyUnitCount", 2L));
-	}
+                mockMvc.perform(get("/api/campaign/SIMPSONS2020X00/interviewers")
+                                                .with(authentication(LOCAL_USER))
+                                                .accept(MediaType.APPLICATION_JSON))
+                                .andExpectAll(
+                                                status().isOk(),
+                                                checkJsonPath(interviewerJsonPath, "interviewerFirstName", "Margie"),
+                                                checkJsonPath(interviewerJsonPath, "interviewerLastName", "Lucas"),
+                                                checkJsonPath(interviewerJsonPath, "email", "margie.lucas@ou.com"),
+                                                checkJsonPath(interviewerJsonPath, "phoneNumber", "+3391231231230"),
+                                                checkJsonPath(interviewerJsonPath, "surveyUnitCount", 2L));
+        }
 
 	/**
 	 * Test that the GET endpoint "api/campaign/{id}/interviewers"

--- a/src/test/java/fr/insee/pearljam/api/campaign/controller/dummy/CampaignFakeService.java
+++ b/src/test/java/fr/insee/pearljam/api/campaign/controller/dummy/CampaignFakeService.java
@@ -8,7 +8,6 @@ import fr.insee.pearljam.api.dto.campaign.CampaignCommonsDto;
 import fr.insee.pearljam.api.dto.campaign.CampaignDto;
 import fr.insee.pearljam.api.dto.campaign.CampaignSensitivityDto;
 import fr.insee.pearljam.api.dto.count.CountDto;
-import fr.insee.pearljam.api.dto.interviewer.InterviewerDto;
 import fr.insee.pearljam.api.service.CampaignService;
 import fr.insee.pearljam.domain.exception.*;
 import lombok.Getter;
@@ -67,11 +66,6 @@ public class CampaignFakeService implements CampaignService {
     @Override
     public List<CampaignDto> getInterviewerCampaigns(String userId) {
         throw new UnsupportedOperationException("Unimplemented method 'getInterviewerCampaigns'");
-    }
-
-    @Override
-    public List<InterviewerDto> getListInterviewers(String userId, String campaignId) {
-        throw new UnsupportedOperationException("Unimplemented method 'getListInterviewers'");
     }
 
     @Override


### PR DESCRIPTION
## Summary
- switch the campaign interviewer projection query to a text block and keep the projection intact
- consolidate campaign interviewer assertions into the Keycloak-auth test suite and drop the redundant controller-level DTO test file

## Testing
- `mvn -q -DskipTests package` *(fails: cannot download spring-boot-starter-parent from Maven Central – HTTP 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69256fceff4083209c7252ad53b6792a)