### PR TITLE
feat(csv exports): unites confiees au site

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ REST API for communication between Pearl Jam DB and Pearl Jam UI.
 
 ## Requirements
 For building and running the application you need:
-- [JDK 21](https://jdk.java.net/archive/)
+- JDK 25
 - Maven 3
 
 ## Project structure (multi-modules)

--- a/pearljam-api/src/main/java/fr/insee/pearljam/api/reporting/export/csv/CsvRow.java
+++ b/pearljam-api/src/main/java/fr/insee/pearljam/api/reporting/export/csv/CsvRow.java
@@ -13,15 +13,20 @@ public record CsvRow(List<String> values) {
     public static CsvRow from(Object... values) {
         List<String> csvValues = Arrays.stream(values)
                 .map(value -> value == null ? "" : String.valueOf(value))
-                .map(value -> {
-                            if (value.contains(SEPARATOR) || value.contains("\"")) {
-                                return "\"" + value.replace("\"", "\"\"") + "\"";
-                            }
-                            return value;
-                        }
-                )
                 .toList();
         return new CsvRow(csvValues);
+    }
+
+    public CsvRow {
+        values.replaceAll(CsvRow::normalize);
+    }
+
+    private static String normalize(String value) {
+        String normalized = value == null ? "" : value;
+        if (normalized.contains(SEPARATOR) || normalized.contains("\"")) {
+            normalized = "\"" + normalized.replace("\"", "\"\"") + "\"";
+        }
+        return normalized;
     }
 
     public static List<Object> emptyRowWithValueAtSpecificPosition(Object value, int positon, int columnCount) {

--- a/pearljam-api/src/main/java/fr/insee/pearljam/api/reporting/export/csv/CsvRow.java
+++ b/pearljam-api/src/main/java/fr/insee/pearljam/api/reporting/export/csv/CsvRow.java
@@ -1,28 +1,33 @@
 package fr.insee.pearljam.api.reporting.export.csv;
 
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public record CsvRow(List<String> values) {
+public class CsvRow {
     private static final String SEPARATOR = ";";
     private static final String LINE_END = "\r\n";
 
+    private final List<String> values;
+
+    private CsvRow(List<String> values) {
+        this.values = values;
+    }
+
+    public List<String> values() {
+        return values;
+    }
+
     public static CsvRow from(Object... values) {
         List<String> csvValues = Arrays.stream(values)
-                .map(value -> value == null ? "" : String.valueOf(value))
+                .map(CsvRow::normalize)
                 .toList();
         return new CsvRow(csvValues);
     }
 
-    public CsvRow {
-        values.replaceAll(CsvRow::normalize);
-    }
-
-    private static String normalize(String value) {
-        String normalized = value == null ? "" : value;
+    private static String normalize(Object value) {
+        String normalized = value == null ? "" : String.valueOf(value);
         if (normalized.contains(SEPARATOR) || normalized.contains("\"")) {
             normalized = "\"" + normalized.replace("\"", "\"\"") + "\"";
         }

--- a/pearljam-api/src/main/java/fr/insee/pearljam/api/surveyunit/controller/SurveyUnitAssignedExportController.java
+++ b/pearljam-api/src/main/java/fr/insee/pearljam/api/surveyunit/controller/SurveyUnitAssignedExportController.java
@@ -31,10 +31,9 @@ public class SurveyUnitAssignedExportController {
     public ResponseEntity<byte[]> exportSurveyUnitAssignedAsCsv(
             @RequestParam(required = false) String search,
             @RequestParam(required = false) String campaignId,
-            @ParameterObject Pageable pageable,
             @CurrentSecurityContext(expression = "authentication.name") String userId) {
         log.info("Exporting survey units to review for user {} with search: {}", userId, search);
-        return surveyUnitAssignedCsvExporter.export(userId, campaignId, search, pageable);
+        return surveyUnitAssignedCsvExporter.export(userId, campaignId, search);
     }
 
 }

--- a/pearljam-api/src/main/java/fr/insee/pearljam/api/surveyunit/controller/SurveyUnitAssignedExportController.java
+++ b/pearljam-api/src/main/java/fr/insee/pearljam/api/surveyunit/controller/SurveyUnitAssignedExportController.java
@@ -1,0 +1,40 @@
+package fr.insee.pearljam.api.surveyunit.controller;
+
+import fr.insee.pearljam.api.surveyunit.export.SurveyUnitAssignedCsvExporter;
+import fr.insee.pearljam.contracts.constants.Constants;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.CurrentSecurityContext;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@Validated
+@Tag(name = "02. Survey-units", description = "Endpoints for survey-units")
+public class SurveyUnitAssignedExportController {
+
+    private final SurveyUnitAssignedCsvExporter surveyUnitAssignedCsvExporter;
+
+    @Operation(summary = "Export assigned survey units as CSV file")
+    @GetMapping(Constants.API_SURVEY_UNITS_ASSIGNED_EXPORT)
+    @Parameter(name = "userId", hidden = true)
+    public ResponseEntity<byte[]> exportSurveyUnitAssignedAsCsv(
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false) String campaignId,
+            @ParameterObject Pageable pageable,
+            @CurrentSecurityContext(expression = "authentication.name") String userId) {
+        log.info("Exporting survey units to review for user {} with search: {}", userId, search);
+        return surveyUnitAssignedCsvExporter.export(userId, campaignId, search, pageable);
+    }
+
+}

--- a/pearljam-api/src/main/java/fr/insee/pearljam/api/surveyunit/csv/SurveyUnitAssignedCsv.java
+++ b/pearljam-api/src/main/java/fr/insee/pearljam/api/surveyunit/csv/SurveyUnitAssignedCsv.java
@@ -12,7 +12,7 @@ public record SurveyUnitAssignedCsv(List<CsvRow> rows) implements CsvExportable 
 
     @Override
     public CsvRow headers() {
-        return new CsvRow(List.of(
+        return CsvRow.from(
                 SurveyUnitAssignedCsvHeaders.TECHNICAL_SURVEY_UNIT_ID.headerName(),
                 SurveyUnitAssignedCsvHeaders.SURVEY_UNIT_ID.headerName(),
                 CollectionCsvHeaders.INTERVIEWER_LABEL.getHeaderName(),
@@ -21,11 +21,11 @@ public record SurveyUnitAssignedCsv(List<CsvRow> rows) implements CsvExportable 
                 SurveyUnitAssignedCsvHeaders.CITY.headerName(),
                 SurveyUnitAssignedCsvHeaders.SURVEY_UNIT_STATE.headerName(),
                 SurveyUnitAssignedCsvHeaders.CLOSING_CAUSE.headerName()
-        ));
+        );
     }
 
     public static CsvRow toCsv(SurveyUnitAssigned surveyUnitAssigned) {
-        return new CsvRow(List.of(
+        return CsvRow.from(
                 surveyUnitAssigned.surveyUnitId(),
                 surveyUnitAssigned.surveyUnitDisplayName(),
                 SurveyUnitAssignedPresenter.buildInterviewerLabel(surveyUnitAssigned),
@@ -34,7 +34,7 @@ public record SurveyUnitAssignedCsv(List<CsvRow> rows) implements CsvExportable 
                 surveyUnitAssigned.city(),
                 surveyUnitAssigned.questionnaireState(),
                 surveyUnitAssigned.closingCause()
-        ));
+        );
     }
 
 }

--- a/pearljam-api/src/main/java/fr/insee/pearljam/api/surveyunit/csv/SurveyUnitAssignedCsv.java
+++ b/pearljam-api/src/main/java/fr/insee/pearljam/api/surveyunit/csv/SurveyUnitAssignedCsv.java
@@ -13,14 +13,14 @@ public record SurveyUnitAssignedCsv(List<CsvRow> rows) implements CsvExportable 
     @Override
     public CsvRow headers() {
         return new CsvRow(List.of(
-                "Identifiant technique",
-                "Identifiant de l'ue",
+                SurveyUnitAssignedCsvHeaders.TECHNICAL_SURVEY_UNIT_ID.headerName(),
+                SurveyUnitAssignedCsvHeaders.SURVEY_UNIT_ID.headerName(),
                 CollectionCsvHeaders.INTERVIEWER_LABEL.getHeaderName(),
-                "Ssech",
-                "Département",
-                "Commune",
-                "Etat de l'UE",
-                "Motif provisoire"
+                SurveyUnitAssignedCsvHeaders.SUB_SAMPLE_ID.headerName(),
+                SurveyUnitAssignedCsvHeaders.LOCATION.headerName(),
+                SurveyUnitAssignedCsvHeaders.CITY.headerName(),
+                SurveyUnitAssignedCsvHeaders.SURVEY_UNIT_STATE.headerName(),
+                SurveyUnitAssignedCsvHeaders.CLOSING_CAUSE.headerName()
         ));
     }
 

--- a/pearljam-api/src/main/java/fr/insee/pearljam/api/surveyunit/csv/SurveyUnitAssignedCsv.java
+++ b/pearljam-api/src/main/java/fr/insee/pearljam/api/surveyunit/csv/SurveyUnitAssignedCsv.java
@@ -1,0 +1,40 @@
+package fr.insee.pearljam.api.surveyunit.csv;
+
+import fr.insee.pearljam.api.reporting.export.collection.CollectionCsvHeaders;
+import fr.insee.pearljam.api.reporting.export.csv.CsvExportable;
+import fr.insee.pearljam.api.reporting.export.csv.CsvRow;
+import fr.insee.pearljam.domain.surveyunit.port.in.SurveyUnitAssignedPresenter;
+import fr.insee.pearljam.domain.surveyunit.readmodel.SurveyUnitAssigned;
+
+import java.util.List;
+
+public record SurveyUnitAssignedCsv(List<CsvRow> rows) implements CsvExportable {
+
+    @Override
+    public CsvRow headers() {
+        return new CsvRow(List.of(
+                "Identifiant technique",
+                "Identifiant de l'ue",
+                CollectionCsvHeaders.INTERVIEWER_LABEL.getHeaderName(),
+                "Ssech",
+                "Département",
+                "Commune",
+                "Etat de l'UE",
+                "Motif provisoire"
+        ));
+    }
+
+    public static CsvRow toCsv(SurveyUnitAssigned surveyUnitAssigned) {
+        return new CsvRow(List.of(
+                surveyUnitAssigned.surveyUnitId(),
+                surveyUnitAssigned.surveyUnitDisplayName(),
+                SurveyUnitAssignedPresenter.buildInterviewerLabel(surveyUnitAssigned),
+                surveyUnitAssigned.ssech(),
+                surveyUnitAssigned.location(),
+                surveyUnitAssigned.city(),
+                surveyUnitAssigned.questionnaireState(),
+                surveyUnitAssigned.closingCause()
+        ));
+    }
+
+}

--- a/pearljam-api/src/main/java/fr/insee/pearljam/api/surveyunit/csv/SurveyUnitAssignedCsvHeaders.java
+++ b/pearljam-api/src/main/java/fr/insee/pearljam/api/surveyunit/csv/SurveyUnitAssignedCsvHeaders.java
@@ -1,0 +1,23 @@
+package fr.insee.pearljam.api.surveyunit.csv;
+
+public enum SurveyUnitAssignedCsvHeaders {
+
+    TECHNICAL_SURVEY_UNIT_ID("Identifiant technique"),
+    SURVEY_UNIT_ID("Identifiant de l'ue"),
+    SUB_SAMPLE_ID("Ssech"),
+    LOCATION("Département"),
+    CITY("Commune"),
+    SURVEY_UNIT_STATE("Etat de l'UE"),
+    CLOSING_CAUSE("Motif provisoire");
+
+    private final String headerName;
+
+    SurveyUnitAssignedCsvHeaders(String headerName) {
+        this.headerName = headerName;
+    }
+
+    public String headerName() {
+        return headerName;
+    }
+
+}

--- a/pearljam-api/src/main/java/fr/insee/pearljam/api/surveyunit/export/SurveyUnitAssignedCsvExporter.java
+++ b/pearljam-api/src/main/java/fr/insee/pearljam/api/surveyunit/export/SurveyUnitAssignedCsvExporter.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 @Service
 @RequiredArgsConstructor
@@ -21,7 +22,7 @@ public class SurveyUnitAssignedCsvExporter extends AbstractCsvExporter {
     public ResponseEntity<byte[]> export(String userId, String campaignId, String search) {
         SurveyUnitAssignedCsv csv = surveyUnitAssignedPort.getSurveyUnitsAssigned(
                 userId, campaignId, search, Pageable.unpaged(), surveyUnitAssignedCsvPresenter);
-        return buildResponse(csv, campaignId + "_UE_confiees" + searchSuffix(search), LocalDate.now());
+        return buildResponse(csv, campaignId + "_UE_confiees" + searchSuffix(search), LocalDate.now(ZoneOffset.UTC));
     }
 
     private static String searchSuffix(String search) {

--- a/pearljam-api/src/main/java/fr/insee/pearljam/api/surveyunit/export/SurveyUnitAssignedCsvExporter.java
+++ b/pearljam-api/src/main/java/fr/insee/pearljam/api/surveyunit/export/SurveyUnitAssignedCsvExporter.java
@@ -1,6 +1,8 @@
 package fr.insee.pearljam.api.surveyunit.export;
 
 import fr.insee.pearljam.api.reporting.export.csv.AbstractCsvExporter;
+import fr.insee.pearljam.api.surveyunit.csv.SurveyUnitAssignedCsv;
+import fr.insee.pearljam.api.surveyunit.presenter.SurveyUnitAssignedCsvPresenter;
 import fr.insee.pearljam.domain.surveyunit.port.in.SurveyUnitAssignedPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;

--- a/pearljam-api/src/main/java/fr/insee/pearljam/api/surveyunit/export/SurveyUnitAssignedCsvExporter.java
+++ b/pearljam-api/src/main/java/fr/insee/pearljam/api/surveyunit/export/SurveyUnitAssignedCsvExporter.java
@@ -1,0 +1,31 @@
+package fr.insee.pearljam.api.surveyunit.export;
+
+import fr.insee.pearljam.api.reporting.export.csv.AbstractCsvExporter;
+import fr.insee.pearljam.domain.surveyunit.port.in.SurveyUnitAssignedPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class SurveyUnitAssignedCsvExporter extends AbstractCsvExporter {
+
+    private final SurveyUnitAssignedCsvPresenter surveyUnitAssignedCsvPresenter;
+    private final SurveyUnitAssignedPort surveyUnitAssignedPort;
+
+    public ResponseEntity<byte[]> export(String userId, String campaignId, String search) {
+        SurveyUnitAssignedCsv csv = surveyUnitAssignedPort.getSurveyUnitsAssigned(
+                userId, campaignId, search, Pageable.unpaged(), surveyUnitAssignedCsvPresenter);
+        return buildResponse(csv, campaignId + "_UE_confiees" + searchSuffix(search), LocalDate.now());
+    }
+
+    private static String searchSuffix(String search) {
+        if (search == null || search.isEmpty())
+            return "";
+        return "_filtre_" + search.replace(' ', '_');
+    }
+
+}

--- a/pearljam-api/src/main/java/fr/insee/pearljam/api/surveyunit/presenter/SurveyUnitAssignedApiPresenter.java
+++ b/pearljam-api/src/main/java/fr/insee/pearljam/api/surveyunit/presenter/SurveyUnitAssignedApiPresenter.java
@@ -38,10 +38,7 @@ public class SurveyUnitAssignedApiPresenter implements
         return new SurveyUnitAssignedResponse(
             surveyUnit.surveyUnitId(),
             surveyUnit.surveyUnitDisplayName(),
-            buildInterviewerLabel(
-                surveyUnit.interviewerFirstName(),
-                surveyUnit.interviewerLastName()
-            ),
+            SurveyUnitAssignedPresenter.buildInterviewerLabel(surveyUnit),
             surveyUnit.ssech(),
             surveyUnit.location(),
             surveyUnit.city(),
@@ -58,12 +55,4 @@ public class SurveyUnitAssignedApiPresenter implements
         return value == null ? null : ClosingCauseType.valueOf(value);
     }
 
-    String buildInterviewerLabel(String firstName, String lastName) {
-
-        String result = Stream.of(firstName, lastName)
-            .filter(Objects::nonNull)
-            .collect(Collectors.joining(" "));
-
-        return result.isBlank() ? "" : result;
-    }
 }

--- a/pearljam-api/src/main/java/fr/insee/pearljam/api/surveyunit/presenter/SurveyUnitAssignedCsvPresenter.java
+++ b/pearljam-api/src/main/java/fr/insee/pearljam/api/surveyunit/presenter/SurveyUnitAssignedCsvPresenter.java
@@ -1,0 +1,25 @@
+package fr.insee.pearljam.api.surveyunit.presenter;
+
+import fr.insee.pearljam.api.reporting.export.csv.CsvRow;
+import fr.insee.pearljam.api.surveyunit.csv.SurveyUnitAssignedCsv;
+import fr.insee.pearljam.domain.surveyunit.port.in.SurveyUnitAssignedPresenter;
+import fr.insee.pearljam.domain.surveyunit.readmodel.SurveyUnitAssigned;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class SurveyUnitAssignedCsvPresenter implements SurveyUnitAssignedPresenter<SurveyUnitAssignedCsv> {
+
+    @Override
+    public SurveyUnitAssignedCsv present(Page<SurveyUnitAssigned> surveyUnits) {
+        if (surveyUnits.getTotalPages() != 1)
+            throw new IllegalArgumentException("Survey unit data for CSV format shouldn't be paginated.");
+        List<CsvRow> rows = surveyUnits.getContent().stream()
+                .map(SurveyUnitAssignedCsv::toCsv)
+                .toList();
+        return new SurveyUnitAssignedCsv(rows);
+    }
+
+}

--- a/pearljam-api/src/test/java/fr/insee/pearljam/api/surveyunit/export/SurveyUnitAssignedCsvExporterTest.java
+++ b/pearljam-api/src/test/java/fr/insee/pearljam/api/surveyunit/export/SurveyUnitAssignedCsvExporterTest.java
@@ -79,8 +79,13 @@ class SurveyUnitAssignedCsvExporterTest {
         assertEquals(2, responseRows.length);
         String expectedHeadersRow = "﻿Identifiant technique;Identifiant de l'ue;Nom Prénom enquêteur;Ssech;Département;Commune;Etat de l'UE;Motif provisoire";
         String expectedContentRow = "foo-id;FOO_LABEL;John Doe;1;33;City;Foo state;-";
-        assertEquals(expectedHeadersRow, responseRows[0]);
-        assertEquals(expectedContentRow, responseRows[1]);
+        assertEquals(expectedHeadersRow, normalize(responseRows[0]));
+        assertEquals(expectedContentRow, normalize(responseRows[1]));
+    }
+
+    /** Get rid of line breaks. */
+    private static String normalize(String line) {
+        return line.replace("\n", "").replace("\r", "");
     }
 
 }

--- a/pearljam-api/src/test/java/fr/insee/pearljam/api/surveyunit/export/SurveyUnitAssignedCsvExporterTest.java
+++ b/pearljam-api/src/test/java/fr/insee/pearljam/api/surveyunit/export/SurveyUnitAssignedCsvExporterTest.java
@@ -80,8 +80,8 @@ class SurveyUnitAssignedCsvExporterTest {
         assertEquals(2, responseRows.length);
         String expectedHeadersRow = "﻿Identifiant technique;Identifiant de l'ue;Nom Prénom enquêteur;Ssech;Département;Commune;Etat de l'UE;Motif provisoire";
         String expectedContentRow = "foo-id;FOO_LABEL;John Doe;1;33;City;Foo state;-";
-        assertThat(responseRows[0]).isEqualToIgnoringNewLines(expectedHeadersRow);
-        assertThat(responseRows[1]).isEqualToIgnoringNewLines(expectedContentRow);
+        assertThat(expectedHeadersRow).isEqualToIgnoringNewLines(responseRows[0]);
+        assertThat(expectedContentRow).isEqualToIgnoringNewLines(responseRows[1]);
     }
 
 }

--- a/pearljam-api/src/test/java/fr/insee/pearljam/api/surveyunit/export/SurveyUnitAssignedCsvExporterTest.java
+++ b/pearljam-api/src/test/java/fr/insee/pearljam/api/surveyunit/export/SurveyUnitAssignedCsvExporterTest.java
@@ -14,7 +14,6 @@ import org.springframework.http.ResponseEntity;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 class SurveyUnitAssignedCsvExporterTest {
@@ -80,8 +79,13 @@ class SurveyUnitAssignedCsvExporterTest {
         assertEquals(2, responseRows.length);
         String expectedHeadersRow = "﻿Identifiant technique;Identifiant de l'ue;Nom Prénom enquêteur;Ssech;Département;Commune;Etat de l'UE;Motif provisoire";
         String expectedContentRow = "foo-id;FOO_LABEL;John Doe;1;33;City;Foo state;-";
-        assertThat(expectedHeadersRow).isEqualToIgnoringNewLines(responseRows[0]);
-        assertThat(expectedContentRow).isEqualToIgnoringNewLines(responseRows[1]);
+        assertEquals(expectedHeadersRow, normalize(responseRows[0]));
+        assertEquals(expectedContentRow, normalize(responseRows[1]));
+    }
+
+    /** Get rid of line breaks. */
+    private static String normalize(String line) {
+        return line.replace("\n", "").replace("\r", "");
     }
 
 }

--- a/pearljam-api/src/test/java/fr/insee/pearljam/api/surveyunit/export/SurveyUnitAssignedCsvExporterTest.java
+++ b/pearljam-api/src/test/java/fr/insee/pearljam/api/surveyunit/export/SurveyUnitAssignedCsvExporterTest.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 class SurveyUnitAssignedCsvExporterTest {
@@ -79,13 +80,8 @@ class SurveyUnitAssignedCsvExporterTest {
         assertEquals(2, responseRows.length);
         String expectedHeadersRow = "﻿Identifiant technique;Identifiant de l'ue;Nom Prénom enquêteur;Ssech;Département;Commune;Etat de l'UE;Motif provisoire";
         String expectedContentRow = "foo-id;FOO_LABEL;John Doe;1;33;City;Foo state;-";
-        assertEquals(expectedHeadersRow, normalize(responseRows[0]));
-        assertEquals(expectedContentRow, normalize(responseRows[1]));
-    }
-
-    /** Get rid of line breaks. */
-    private static String normalize(String line) {
-        return line.replace("\n", "").replace("\r", "");
+        assertThat(responseRows[0]).isEqualToIgnoringNewLines(expectedHeadersRow);
+        assertThat(responseRows[1]).isEqualToIgnoringNewLines(expectedContentRow);
     }
 
 }

--- a/pearljam-api/src/test/java/fr/insee/pearljam/api/surveyunit/export/SurveyUnitAssignedCsvExporterTest.java
+++ b/pearljam-api/src/test/java/fr/insee/pearljam/api/surveyunit/export/SurveyUnitAssignedCsvExporterTest.java
@@ -1,0 +1,86 @@
+package fr.insee.pearljam.api.surveyunit.export;
+
+import fr.insee.pearljam.api.surveyunit.presenter.SurveyUnitAssignedCsvPresenter;
+import fr.insee.pearljam.domain.surveyunit.port.in.SurveyUnitAssignedPort;
+import fr.insee.pearljam.domain.surveyunit.port.in.SurveyUnitAssignedPresenter;
+import fr.insee.pearljam.domain.surveyunit.readmodel.SurveyUnitAssigned;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SurveyUnitAssignedCsvExporterTest {
+
+    private final SurveyUnitAssignedPort stubbedPort = new SurveyUnitAssignedPort() {
+        @Override
+        public <T> T getSurveyUnitsAssigned(
+                String userId, String campaignId, String search, Pageable pageable,
+                SurveyUnitAssignedPresenter<T> presenter) {
+            return presenter.present(new PageImpl<>(List.of(fooSurveyUnitAssigned())));
+        }
+    };
+
+    private final SurveyUnitAssignedCsvPresenter csvPresenter = new SurveyUnitAssignedCsvPresenter();
+
+    private static @NonNull SurveyUnitAssigned fooSurveyUnitAssigned() {
+        return new SurveyUnitAssigned(
+                "foo-id",
+                "FOO_LABEL",
+                "1",
+                "John",
+                "Doe",
+                "33",
+                "City",
+                "Foo state",
+                "-");
+    }
+
+    private SurveyUnitAssignedCsvExporter csvExporter;
+
+    @BeforeEach
+    void setUp() {
+        csvExporter = new SurveyUnitAssignedCsvExporter(csvPresenter, stubbedPort);
+    }
+
+    @Test
+    void fileNameTest() {
+        ResponseEntity<byte[]> response = csvExporter.export("foo-user-id", "FOO_CAMPAIGN", "");
+
+        String responseFileName = response.getHeaders().getContentDisposition().getFilename();
+        assertNotNull(responseFileName);
+        String expectedFilename = "^FOO_CAMPAIGN_UE_confiees_[0-9]{8}.csv$";
+        assertTrue(Pattern.matches(expectedFilename, responseFileName));
+    }
+
+    @Test
+    void fileNameTest_withSearch() {
+        ResponseEntity<byte[]> response = csvExporter.export("foo-user-id", "FOO_CAMPAIGN", "search value");
+
+        String responseFilename = response.getHeaders().getContentDisposition().getFilename();
+        assertNotNull(responseFilename);
+        String expectedFilename = "^FOO_CAMPAIGN_UE_confiees_filtre_search_value_[0-9]{8}.csv$";
+        assertTrue(Pattern.matches(expectedFilename, responseFilename));
+    }
+
+    @Test
+    void responseCsvContent() {
+        ResponseEntity<byte[]> response = csvExporter.export("foo-user-id", "FOO_CAMPAIGN", "");
+
+        assertNotNull(response.getBody());
+        String responseBody = new String(response.getBody());
+        String[] responseRows = responseBody.split(System.lineSeparator());
+        assertEquals(2, responseRows.length);
+        String expectedHeadersRow = "﻿Identifiant technique;Identifiant de l'ue;Nom Prénom enquêteur;Ssech;Département;Commune;Etat de l'UE;Motif provisoire";
+        String expectedContentRow = "foo-id;FOO_LABEL;John Doe;1;33;City;Foo state;-";
+        assertEquals(expectedHeadersRow, responseRows[0]);
+        assertEquals(expectedContentRow, responseRows[1]);
+    }
+
+}

--- a/pearljam-api/src/test/java/fr/insee/pearljam/api/surveyunit/presenter/SurveyUnitAssignedApiPresenterTest.java
+++ b/pearljam-api/src/test/java/fr/insee/pearljam/api/surveyunit/presenter/SurveyUnitAssignedApiPresenterTest.java
@@ -1,11 +1,9 @@
 package fr.insee.pearljam.api.surveyunit.presenter;
 
 import fr.insee.pearljam.domain.surveyunit.model.StateType;
-import fr.insee.pearljam.domain.surveyunit.port.in.SurveyUnitAssignedPresenter;
 import fr.insee.pearljam.domain.surveyunit.readmodel.SurveyUnitAssigned;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.data.domain.Page;
@@ -91,24 +89,6 @@ class SurveyUnitAssignedApiPresenterTest {
     void toStateType_shouldThrowException_whenValueIsInvalid(String value) {
         assertThatThrownBy(() -> presenter.toStateType(value))
             .isInstanceOf(IllegalArgumentException.class);
-    }
-
-
-    @ParameterizedTest
-    @CsvSource(value = {
-        "Jean,Dupont,Jean Dupont",
-        "Marie,Martin,Marie Martin",
-        "Élodie,Dubois,Élodie Dubois",
-        "Jean-Pierre,Durand,Jean-Pierre Durand",
-        "Jean Claude,Martin,Jean Claude Martin",
-        "Louis de,Fontaine,Louis de Fontaine",
-        ",Durand,Durand",
-        "Marie,,Marie",
-        ",, ''"
-    })
-    void buildInterviewerLabel_shouldHandleFrenchNames(String firstName, String lastName, String expected) {
-        assertThat(SurveyUnitAssignedPresenter.buildInterviewerLabel(firstName, lastName))
-            .isEqualTo(expected);
     }
 
 }

--- a/pearljam-api/src/test/java/fr/insee/pearljam/api/surveyunit/presenter/SurveyUnitAssignedApiPresenterTest.java
+++ b/pearljam-api/src/test/java/fr/insee/pearljam/api/surveyunit/presenter/SurveyUnitAssignedApiPresenterTest.java
@@ -1,6 +1,7 @@
 package fr.insee.pearljam.api.surveyunit.presenter;
 
 import fr.insee.pearljam.domain.surveyunit.model.StateType;
+import fr.insee.pearljam.domain.surveyunit.port.in.SurveyUnitAssignedPresenter;
 import fr.insee.pearljam.domain.surveyunit.readmodel.SurveyUnitAssigned;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -106,7 +107,7 @@ class SurveyUnitAssignedApiPresenterTest {
         ",, ''"
     })
     void buildInterviewerLabel_shouldHandleFrenchNames(String firstName, String lastName, String expected) {
-        assertThat(presenter.buildInterviewerLabel(firstName, lastName))
+        assertThat(SurveyUnitAssignedPresenter.buildInterviewerLabel(firstName, lastName))
             .isEqualTo(expected);
     }
 

--- a/pearljam-api/src/test/java/fr/insee/pearljam/api/surveyunit/presenter/SurveyUnitAssignedCsvPresenterTest.java
+++ b/pearljam-api/src/test/java/fr/insee/pearljam/api/surveyunit/presenter/SurveyUnitAssignedCsvPresenterTest.java
@@ -1,0 +1,66 @@
+package fr.insee.pearljam.api.surveyunit.presenter;
+
+import fr.insee.pearljam.api.reporting.export.csv.CsvRow;
+import fr.insee.pearljam.api.surveyunit.csv.SurveyUnitAssignedCsv;
+import fr.insee.pearljam.domain.surveyunit.readmodel.SurveyUnitAssigned;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SurveyUnitAssignedCsvPresenterTest {
+
+    private final SurveyUnitAssignedCsvPresenter presenter = new SurveyUnitAssignedCsvPresenter();
+
+    private static void assertHeadersIsCorrect(CsvRow headersRow) {
+        assertEquals(8, headersRow.values().size());
+        // maybe other assertions
+    }
+
+    @Test
+    void emptyContent_emptyCsv() {
+        SurveyUnitAssignedCsv result = presenter.present(Page.empty());
+        assertHeadersIsCorrect(result.headers());
+        assertEquals(0, result.rows().size());
+    }
+
+    @Test
+    void shouldThrowIfPaginatedContent() {
+        Page<SurveyUnitAssigned> paginatedSurveyUnits = new PageImpl<>(
+                List.of(fooSurveyUnitAssigned(), fooSurveyUnitAssigned()),
+                PageRequest.of(1, 2),
+                10
+        );
+        assertThrows(Exception.class, () -> presenter.present(paginatedSurveyUnits));
+    }
+
+    @Test
+    void fooCsvRow() {
+        Page<SurveyUnitAssigned> surveyUnit = new PageImpl<>(List.of(fooSurveyUnitAssigned()));
+        SurveyUnitAssignedCsv result = presenter.present(surveyUnit);
+        assertHeadersIsCorrect(result.headers());
+        assertEquals(1, result.rows().size());
+        assertEquals(
+                List.of("foo-id", "FOO_LABEL", "John Doe", "1", "33", "City", "Foo state", "-"),
+                result.rows().getFirst().values());
+    }
+
+    private static @NonNull SurveyUnitAssigned fooSurveyUnitAssigned() {
+        return new SurveyUnitAssigned(
+                "foo-id",
+                "FOO_LABEL",
+                "1",
+                "John",
+                "Doe",
+                "33",
+                "City",
+                "Foo state",
+                "-");
+    }
+
+}

--- a/pearljam-domain/src/main/java/fr/insee/pearljam/domain/surveyunit/port/in/SurveyUnitAssignedPresenter.java
+++ b/pearljam-domain/src/main/java/fr/insee/pearljam/domain/surveyunit/port/in/SurveyUnitAssignedPresenter.java
@@ -3,6 +3,10 @@ package fr.insee.pearljam.domain.surveyunit.port.in;
 import fr.insee.pearljam.domain.surveyunit.readmodel.SurveyUnitAssigned;
 import org.springframework.data.domain.Page;
 
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 /**
  * Presenter interface for formatting survey units assigned responses.
  * Implementations of this interface are responsible for transforming the domain model
@@ -19,4 +23,19 @@ public interface SurveyUnitAssignedPresenter<T> {
      * @return the formatted response
      */
     T present(Page<SurveyUnitAssigned> surveyUnits);
+
+    static String buildInterviewerLabel(SurveyUnitAssigned surveyUnitAssigned) {
+        String firstName = surveyUnitAssigned.interviewerFirstName();
+        String lastName = surveyUnitAssigned.interviewerLastName();
+        return buildInterviewerLabel(firstName, lastName);
+    }
+
+    static String buildInterviewerLabel(String firstName, String lastName) {
+        String result = Stream.of(firstName, lastName)
+                .filter(Objects::nonNull)
+                .collect(Collectors.joining(" "));
+
+        return result.isBlank() ? "" : result;
+    }
+
 }

--- a/pearljam-domain/src/test/java/fr/insee/pearljam/domain/surveyunit/port/in/SurveyUnitAssignedPresenterTest.java
+++ b/pearljam-domain/src/test/java/fr/insee/pearljam/domain/surveyunit/port/in/SurveyUnitAssignedPresenterTest.java
@@ -1,0 +1,27 @@
+package fr.insee.pearljam.domain.surveyunit.port.in;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SurveyUnitAssignedPresenterTest {
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            "Jean,Dupont,Jean Dupont",
+            "Marie,Martin,Marie Martin",
+            "Élodie,Dubois,Élodie Dubois",
+            "Jean-Pierre,Durand,Jean-Pierre Durand",
+            "Jean Claude,Martin,Jean Claude Martin",
+            "Louis de,Fontaine,Louis de Fontaine",
+            ",Durand,Durand",
+            "Marie,,Marie",
+            ",, ''"
+    })
+    void buildInterviewerLabel_shouldHandleFrenchNames(String firstName, String lastName, String expected) {
+        assertThat(SurveyUnitAssignedPresenter.buildInterviewerLabel(firstName, lastName))
+                .isEqualTo(expected);
+    }
+
+}

--- a/pearljam-infrastructure-persistence/src/main/java/fr/insee/pearljam/infrastructure/persistence/surveyunit/adapter/SurveyUnitAssignedDaoAdapter.java
+++ b/pearljam-infrastructure-persistence/src/main/java/fr/insee/pearljam/infrastructure/persistence/surveyunit/adapter/SurveyUnitAssignedDaoAdapter.java
@@ -96,21 +96,30 @@ public class SurveyUnitAssignedDaoAdapter implements SurveyUnitAssignedRepositor
                             AND su.organization_unit_id in (:ouIds)
                          """ +
                      buildSearchCondition(search) +
-                     PaginationHelpers.buildSortClause(pageable, ALLOWED_SORTS) +
-                     """
-                         LIMIT :limit OFFSET :offset
-                         """;
+                     PaginationHelpers.buildSortClause(pageable, ALLOWED_SORTS);
 
-        return jdbc.sql(sql)
-            .param("campaignIds", campaignIds)
-            .param("ouIds", lstOuIds)
-            .param("search", "%" + (search != null ? search.toLowerCase() : "") + "%")
-            .param("limit", pageable.getPageSize())
-            .param("offset", pageable.getOffset())
+
+        boolean isPaged = pageable.isPaged();
+        if (isPaged) {
+            sql += """
+                        LIMIT :limit OFFSET :offset
+                        """;
+        }
+
+        JdbcClient.StatementSpec statementSpec = jdbc.sql(sql)
+                .param("campaignIds", campaignIds)
+                .param("ouIds", lstOuIds)
+                .param("search", "%" + (search != null ? search.toLowerCase() : "") + "%");
+
+        if (isPaged) {
+            statementSpec = statementSpec
+                    .param("limit", pageable.getPageSize())
+                    .param("offset", pageable.getOffset());
+        }
+
+        return statementSpec
             .query(this::mapToSurveyUnitAssigned)
             .list();
-
-
     }
 
     private long executeCountQuery(List<String> campaignIds, List<String> lstOuIds, String search) {

--- a/pearljam-infrastructure-persistence/src/test/java/fr/insee/pearljam/infrastructure/persistence/surveyunit/adapter/SurveyUnitAssignedDaoAdapterTest.java
+++ b/pearljam-infrastructure-persistence/src/test/java/fr/insee/pearljam/infrastructure/persistence/surveyunit/adapter/SurveyUnitAssignedDaoAdapterTest.java
@@ -41,6 +41,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 
 @SpringBootTest
@@ -436,4 +437,18 @@ class SurveyUnitAssignedDaoAdapterTest {
 
         assertThat(values).isSorted();
     }
+
+    @Test
+    void findSurveyUnitsAssigned_unpaged_shouldReturnAllEntries() {
+        // Given
+        List<String> campaignIds = List.of(CAMPAIGN_1_ID);
+        List<String> lstOuIds = List.of(OU_1);
+        String search = "";
+        Pageable unpaged = Pageable.unpaged();
+        // When
+        Page<SurveyUnitAssigned> result = adapter.findSurveyUnitsAssigned(campaignIds, lstOuIds, search, unpaged);
+        // Then
+        assertNotNull(result);
+    }
+
 }

--- a/pearljam-infrastructure-security/src/main/java/fr/insee/pearljam/infrastructure/security/config/OidcSecurityConfiguration.java
+++ b/pearljam-infrastructure-security/src/main/java/fr/insee/pearljam/infrastructure/security/config/OidcSecurityConfiguration.java
@@ -345,6 +345,8 @@ public class OidcSecurityConfiguration {
 						.hasAnyRole(adminRole, nationalUserRole, localUserRole)
                         .requestMatchers(HttpMethod.GET, Constants.API_SURVEY_UNITS_ASSIGNED)
                         .hasAnyRole(adminRole, nationalUserRole, localUserRole)
+						.requestMatchers(HttpMethod.GET, Constants.API_SURVEY_UNITS_ASSIGNED_EXPORT)
+						.hasAnyRole(adminRole, nationalUserRole, localUserRole)
 						.anyRequest()
 						.denyAll());
 	}

--- a/pearljam-shared-dto/src/main/java/fr/insee/pearljam/contracts/constants/Constants.java
+++ b/pearljam-shared-dto/src/main/java/fr/insee/pearljam/contracts/constants/Constants.java
@@ -33,6 +33,7 @@ public class Constants {
   public static final String API_SURVEYUNITS_ADD_STATE = "/api/survey-units/states";
   public static final String API_SURVEYUNIT_HISTORY = "/api/survey-units/{surveyUnitId}/history";
   public static final String API_SURVEY_UNITS_ASSIGNED = "/api/survey-units/assigned";
+  public static final String API_SURVEY_UNITS_ASSIGNED_EXPORT = "/api/survey-units/assigned/export";
 
   public static final String API_SURVEY_UNITS_TO_REVIEW = "/api/survey-units/to-review";
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <name>Pearl-Jam-Back-Office Parent</name>
 
     <properties>
-        <revision>5.36.0</revision>
+        <revision>5.37.0</revision>
         <changelist></changelist>
         <java.version>25</java.version>
         <maven.compiler.source>25</maven.compiler.source>


### PR DESCRIPTION
Export csv pour le tableau "Unités confiées au site" dans "Informations utiles".

Endpoint `GET /api/survey-units/assigned/export`

avec les mêmes paramètres que `GET /api/survey-units/assigned`, hormis la pagination (pas de pagination pour l'export csv).
